### PR TITLE
Implement slot-specific item instance data tracking

### DIFF
--- a/addons/rubonnek.inventory_manager/runtime/excess_items.gd
+++ b/addons/rubonnek.inventory_manager/runtime/excess_items.gd
@@ -33,23 +33,37 @@ class_name ExcessItems
 ##
 ## The item amount is always positive and not clamped.
 
-var _m_item_registry: ItemRegistry
-var _m_item_slot_data: PackedInt64Array
+var _m_item_registry: ItemRegistry = null
+var _m_item_id: int = 0
+var _m_item_amount: int = 0
+var _m_instance_data: Variant = null
 
 
 ## Returns the item ID.
 func get_item_id() -> int:
-	return _m_item_slot_data[0]
+	return _m_item_id
 
 
 ## Sets the item_amount.
 func set_amount(p_amount: int) -> void:
-	_m_item_slot_data[1] = p_amount
+	_m_item_amount = p_amount
 
 
 ## Returns the item amount.
 func get_amount() -> int:
-	return _m_item_slot_data[1]
+	return _m_item_amount
+
+
+## Sets the item instance data.
+func set_instance_data(p_instance_data: Variant) -> void:
+	_m_instance_data = p_instance_data
+
+
+## Returns the item instance data that was installed in the inventory. If there wasn't any, the retuning value will fallback to the instance data from the item registry if any. Returns null when none are available.
+func get_instance_data() -> Variant:
+	if _m_instance_data == null:
+		return _m_item_registry.get_instance_data(_m_item_id)
+	return _m_instance_data
 
 
 ## Returns the associated [ItemRegistry].
@@ -73,9 +87,11 @@ func get_icon() -> Texture2D:
 
 
 func _to_string() -> String:
-	return "<ExcessItems#%d> Item ID: %d, Name: \"%s\", Amount: %d" % [get_instance_id(), get_item_id(), get_name(), get_amount()]
+	return "<ExcessItems#%d> Item ID: %d, Name: \"%s\", Amount: %d, Instance Data: %s" % [get_instance_id(), get_item_id(), get_name(), get_amount(), str(get_instance_data())]
 
 
-func _init(p_item_registry: ItemRegistry, p_item_slot_data: PackedInt64Array) -> void:
+func _init(p_item_registry: ItemRegistry, p_item_id: int, p_item_amount: int, p_instance_data: Variant = null) -> void:
 	_m_item_registry = p_item_registry
-	_m_item_slot_data = p_item_slot_data
+	_m_item_id = p_item_id
+	_m_item_amount = p_item_amount
+	_m_instance_data = p_instance_data


### PR DESCRIPTION
This is particularly useful for crafting games, or incremental or  "numbers go up" games where crafting items with variable properties is part of the gameplay loop.

Currently it's possible to implement such mechanics with inventory manager but it has some drawbacks:
* Implementing item generation by registering items via ItemRegistry is clunky -- you'll have to generate a new item ID for each item you generate in order to track its variable properties. When the amount of possible items you can generate is small, this is not a problem, but when the amount of possible items is high then this will highly impact memory usage which can be minimized by having an inventory manager that can handle both: static and dynamic items with specific instance data.
* Attempting to track custom item properties via the item registry will bloat the metadata for the specified item id and while it is possible to tracking inventory slot metadata via item registry, this is highly discouraged since functions such as `InventoryManager.organize` will mix slots with associated instance data. Users will have to implement their own `InventoryManager.organize` wrapper.
*  Item metadata in ItemRegistry was originally meant to track global properties of items (such as price or other values that might apply globally to each item), and not meant to track slot-specific item instance data.

The solution solution I'm proposing in this patch to the points above is to add the ability to register a global item instance data in ItemRegistry and also allow inventory manager to track slot-specific item instances via `Variant`, as well as registering an instance data comparator needed for `Object` extensions so that inventory manager can tell when these objects are the same as the registered instance in the registry or not. The comparator is particularly useful for projects that already have the items built but not an inventory manager. In this particular case a global, fallback item instance can be registered in the ItemRegistry and this instance (or similar instances) can be used to add items into inventory manager.

This particular change will make it so that:
* Items that share item ID will also share stack capacity and stack count limits.
* Items with variable instances, but the same item ID, will be added to new slots unless the comparator deems them equal.

This is an API breaking change.